### PR TITLE
Type Saftey for Dragon Backend

### DIFF
--- a/smartsim/_core/entrypoints/dragon.py
+++ b/smartsim/_core/entrypoints/dragon.py
@@ -33,7 +33,6 @@ import typing as t
 from types import FrameType
 
 import zmq
-from pydantic import ValidationError
 
 import smartsim._core.utils.helpers as _helpers
 from smartsim._core.launcher.dragon.dragonBackend import DragonBackend

--- a/smartsim/_core/entrypoints/dragon.py
+++ b/smartsim/_core/entrypoints/dragon.py
@@ -114,13 +114,13 @@ def main(args: argparse.Namespace) -> int:
         launcher_socket.connect(args.launching_address)
 
         response = (
-            _helpers.Pipeline(DragonBootstrapRequest(address=dragon_head_address))
-            .pipe(request_serializer.serialize_to_json)
-            .pipe(launcher_socket.send_json)
-            .pipe(lambda _: launcher_socket.recv_json())
-            .pipe(str)
-            .pipe(response_serializer.deserialize_from_json)
-            .result()
+            _helpers.start_with(DragonBootstrapRequest(address=dragon_head_address))
+            .then(request_serializer.serialize_to_json)
+            .then(launcher_socket.send_json)
+            .then(lambda _: launcher_socket.recv_json())
+            .then(str)
+            .then(response_serializer.deserialize_from_json)
+            .get_result()
         )
 
         if not isinstance(response, DragonBootstrapResponse):

--- a/smartsim/_core/entrypoints/dragon.py
+++ b/smartsim/_core/entrypoints/dragon.py
@@ -37,6 +37,8 @@ from pydantic import ValidationError
 
 from smartsim._core.launcher.dragon.dragonBackend import DragonBackend
 from smartsim._core.schemas import DragonBootstrapRequest, DragonBootstrapResponse
+from smartsim._core.schemas.dragonRequests import request_serializer
+from smartsim._core.schemas.dragonResponses import response_serializer
 from smartsim._core.utils.network import get_best_interface_and_address
 
 # kill is not catchable
@@ -89,10 +91,10 @@ def run(dragon_head_address: str) -> None:
         print(f"Listening to {dragon_head_address}")
         req = dragon_head_socket.recv_json()
         print(f"Received request: {req}")
-        json_req = json.loads(str(req))
-        resp = dragon_backend.process_request(json_req)
+        drg_req = request_serializer.deserialize_from_json(str(req))
+        resp = dragon_backend.process_request(drg_req)
         print(f"Sending response {resp}", flush=True)
-        dragon_head_socket.send_json(resp.json())
+        dragon_head_socket.send_json(response_serializer.serialize_to_json(resp))
 
 
 def main(args: argparse.Namespace) -> int:
@@ -111,14 +113,15 @@ def main(args: argparse.Namespace) -> int:
         launcher_socket = context.socket(zmq.REQ)
         launcher_socket.connect(args.launching_address)
         request = DragonBootstrapRequest(address=dragon_head_address)
-        launcher_socket.send_json(request.json())
+        launcher_socket.send_json(request_serializer.serialize_to_json(request))
         message = t.cast(str, launcher_socket.recv_json())
-        try:
-            DragonBootstrapResponse.parse_obj(json.loads(message))
-        except ValidationError as e:
+
+        if not isinstance(
+            response_serializer.deserialize_from_json(message), DragonBootstrapResponse
+        ):
             raise ValueError(
                 "Could not receive connection confirmation from launcher. Aborting."
-            ) from e
+            )
 
     print_summary(interface, dragon_head_address)
 

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -72,6 +72,8 @@ class DragonBackend:
             return str(self._step_id)
 
     @functools.singledispatchmethod
+    # Deliberately suppressing errors so that overload have same signature
+    # pylint: disable-next=no-self-use
     def process_request(self, request: DragonRequest) -> DragonResponse:
         raise TypeError("Unsure how to process a `{type(request)}` request")
 
@@ -135,5 +137,7 @@ class DragonBackend:
         return DragonStopResponse()
 
     @process_request.register
+    # Deliberately suppressing errors so that overload have same signature
+    # pylint: disable-next=no-self-use,unused-argument
     def _(self, request: DragonHandshakeRequest) -> DragonHandshakeResponse:
         return DragonHandshakeResponse()

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -72,7 +72,7 @@ class DragonBackend:
             return str(self._step_id)
 
     @functools.singledispatchmethod
-    # Deliberately suppressing errors so that overload have same signature
+    # Deliberately suppressing errors so that overloads have the same signature
     # pylint: disable-next=no-self-use
     def process_request(self, request: DragonRequest) -> DragonResponse:
         raise TypeError("Unsure how to process a `{type(request)}` request")
@@ -137,7 +137,7 @@ class DragonBackend:
         return DragonStopResponse()
 
     @process_request.register
-    # Deliberately suppressing errors so that overload have same signature
+    # Deliberately suppressing errors so that overloads have the same signature
     # pylint: disable-next=no-self-use,unused-argument
     def _(self, request: DragonHandshakeRequest) -> DragonHandshakeResponse:
         return DragonHandshakeResponse()

--- a/smartsim/_core/launcher/dragon/dragonBackend.py
+++ b/smartsim/_core/launcher/dragon/dragonBackend.py
@@ -24,6 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import functools
 import typing as t
 from threading import RLock
 
@@ -61,14 +62,6 @@ class DragonBackend:
     """
 
     def __init__(self) -> None:
-        self._request_to_function: t.Mapping[
-            str, t.Callable[[t.Any], DragonResponse]
-        ] = {
-            "run": self.run,
-            "update_status": self.update_status,
-            "stop": self.stop,
-            "handshake": DragonBackend.handshake,
-        }
         self._proc_groups: t.Dict[str, t.Tuple[ProcessGroup, t.List[int]]] = {}
         self._step_id_lock = RLock()
         self._step_id = 0
@@ -78,29 +71,23 @@ class DragonBackend:
             self._step_id += 1
             return str(self._step_id)
 
+    @functools.singledispatchmethod
     def process_request(self, request: DragonRequest) -> DragonResponse:
-        req_type = DragonRequest.parse_obj(request).request_type
-        if not req_type:
-            raise ValueError("Malformed request contains empty ``request_type`` field.")
-        if req_type not in self._request_to_function:
-            raise ValueError(f"Unknown request type {req_type}.")
+        raise TypeError("Unsure how to process a `{type(request)}` request")
 
-        return self._request_to_function[req_type](request)
-
-    def run(self, request: DragonRunRequest) -> DragonRunResponse:
-        run_request = DragonRunRequest.parse_obj(request)
-
+    @process_request.register
+    def _(self, request: DragonRunRequest) -> DragonRunResponse:
         proc = TemplateProcess(
-            target=run_request.exe,
-            args=run_request.exe_args,
-            cwd=run_request.path,
-            env={**run_request.current_env, **run_request.env},
+            target=request.exe,
+            args=request.exe_args,
+            cwd=request.path,
+            env={**request.current_env, **request.env},
             # stdout=Popen.PIPE,
             # stderr=Popen.PIPE,
         )
 
         grp = ProcessGroup(restart=False, pmi_enabled=True)
-        grp.add_process(nproc=run_request.tasks, template=proc)
+        grp.add_process(nproc=request.tasks, template=proc)
         step_id = self._get_new_id()
         grp.init()
         grp.start()
@@ -108,13 +95,10 @@ class DragonBackend:
 
         return DragonRunResponse(step_id=step_id)
 
-    def update_status(
-        self, request: DragonUpdateStatusRequest
-    ) -> DragonUpdateStatusResponse:
-        update_status_request = DragonUpdateStatusRequest.parse_obj(request)
-
+    @process_request.register
+    def _(self, request: DragonUpdateStatusRequest) -> DragonUpdateStatusResponse:
         updated_statuses: t.Dict[str, t.Tuple[str, t.Optional[t.List[int]]]] = {}
-        for step_id in update_status_request.step_ids:
+        for step_id in request.step_ids:
             return_codes: t.List[int] = []
             if step_id in self._proc_groups:
                 proc_group_tuple = self._proc_groups[step_id]
@@ -139,20 +123,17 @@ class DragonBackend:
 
         return DragonUpdateStatusResponse(statuses=updated_statuses)
 
-    def stop(self, request: DragonStopRequest) -> DragonStopResponse:
-        stop_request = DragonStopRequest.parse_obj(request)
-
-        if stop_request.step_id in self._proc_groups:
+    @process_request.register
+    def _(self, request: DragonStopRequest) -> DragonStopResponse:
+        if request.step_id in self._proc_groups:
             # Technically we could just terminate, but what if
             # the application intercepts that and ignores it?
-            proc_group = self._proc_groups[stop_request.step_id][0]
+            proc_group = self._proc_groups[request.step_id][0]
             if proc_group.status == "Running":
                 proc_group.kill()
 
         return DragonStopResponse()
 
-    @staticmethod
-    def handshake(request: DragonHandshakeRequest) -> DragonHandshakeResponse:
-        DragonHandshakeRequest.parse_obj(request)
-
+    @process_request.register
+    def _(self, request: DragonHandshakeRequest) -> DragonHandshakeResponse:
         return DragonHandshakeResponse()

--- a/smartsim/_core/launcher/dragon/dragonLauncher.py
+++ b/smartsim/_core/launcher/dragon/dragonLauncher.py
@@ -38,6 +38,9 @@ from threading import RLock
 
 import zmq
 
+from smartsim._core.schemas.dragonRequests import request_serializer
+from smartsim._core.schemas.dragonResponses import response_serializer
+
 from ....error import LauncherError
 from ....log import get_logger
 from ....settings import DragonRunSettings, RunSettings, SettingsBase
@@ -49,6 +52,7 @@ from ...schemas import (
     DragonHandshakeRequest,
     DragonHandshakeResponse,
     DragonRequest,
+    DragonResponse,
     DragonRunRequest,
     DragonRunResponse,
     DragonStopRequest,
@@ -62,6 +66,8 @@ from ..step import DragonStep, LocalStep, Step
 from ..stepInfo import StepInfo
 
 logger = get_logger(__name__)
+
+_SchemaT = t.TypeVar("_SchemaT", bound=t.Union[DragonRequest, DragonResponse])
 
 
 class DragonLauncher(WLMLauncher):
@@ -96,8 +102,9 @@ class DragonLauncher(WLMLauncher):
         self._dragon_head_socket.connect(address)
         request = DragonHandshakeRequest()
         try:
-            response = self._send_request_as_json(request)
-            DragonHandshakeResponse.parse_obj(response)
+            response = _assert_schema_type(
+                DragonHandshakeResponse, self._send_request_as_json(request)
+            )
             logger.debug(
                 f"Successful handshake with Dragon server at address {address}"
             )
@@ -186,12 +193,14 @@ class DragonLauncher(WLMLauncher):
 
             if address is not None:
                 logger.debug(f"Listening to {socket_addr}")
-                dragon_address_request = DragonBootstrapRequest.parse_obj(
-                    json.loads(str(launcher_socket.recv_json()))
+                dragon_address_request = request_serializer.deserialize_from_json(
+                    str(launcher_socket.recv_json())
                 )
                 dragon_head_address = dragon_address_request.address
                 logger.debug(f"Connecting launcher to {dragon_head_address}")
-                launcher_socket.send_json(DragonBootstrapResponse().json())
+                launcher_socket.send_json(
+                    response_serializer.serialize_to_json(DragonBootstrapResponse())
+                )
                 launcher_socket.close()
                 self._set_timeout(self._timeout)
                 self._handsake(dragon_head_address)
@@ -237,9 +246,10 @@ class DragonLauncher(WLMLauncher):
                 exe=cmd[0], exe_args=cmd[1:], path=step.cwd, name=step.entity_name
             )
 
-        response = self._send_request_as_json(req)
-        run_response = DragonRunResponse.parse_obj(response)
-        step_id = str(run_response.step_id)
+        response = _assert_schema_type(
+            DragonRunResponse, self._send_request_as_json(req)
+        )
+        step_id = str(response.step_id)
         task_id = step_id
 
         self.step_mapping.add(step.name, step_id, task_id, step.managed)
@@ -262,9 +272,9 @@ class DragonLauncher(WLMLauncher):
 
         step_id = str(stepmap.step_id)
         request = DragonStopRequest(step_id=step_id)
-        response = self._send_request_as_json(request)
-
-        DragonStopResponse.parse_obj(response)
+        response = _assert_schema_type(
+            DragonStopResponse, self._send_request_as_json(request)
+        )
 
         _, step_info = self.get_step_update([step_name])[0]
         if not step_info:
@@ -286,21 +296,22 @@ class DragonLauncher(WLMLauncher):
             raise LauncherError("Launcher is not connected to Dragon.")
 
         request = DragonUpdateStatusRequest(step_ids=step_ids)
-        response = self._send_request_as_json(request)
+        response = _assert_schema_type(
+            DragonUpdateStatusResponse, self._send_request_as_json(request)
+        )
 
-        update_response = DragonUpdateStatusResponse.parse_obj(response)
         # create SlurmStepInfo objects to return
         updates: t.List[StepInfo] = []
         # Order matters as we return an ordered list of StepInfo objects
         for step_id in step_ids:
-            if step_id not in update_response.statuses:
+            if step_id not in response.statuses:
                 msg = "Missing step id update from Dragon launcher."
-                if update_response.error_message is not None:
+                if response.error_message is not None:
                     msg += "\nDragon backend reported following error: "
-                    msg += update_response.error_message
+                    msg += response.error_message
                 raise LauncherError(msg)
 
-            stat_tuple = update_response.statuses[step_id]
+            stat_tuple = response.statuses[step_id]
             ret_codes = stat_tuple[1]
             if ret_codes:
                 grp_ret_code = min(ret_codes)
@@ -316,16 +327,16 @@ class DragonLauncher(WLMLauncher):
 
     def _send_request_as_json(
         self, request: DragonRequest, flags: int = 0
-    ) -> t.Mapping[str, t.Any]:
+    ) -> DragonResponse:
         if self._dragon_head_socket is None:
             raise LauncherError("Launcher is not connected to Dragon")
 
         with self._comm_lock:
-            req_json = request.json()
+            req_json = request_serializer.serialize_to_json(request)
             logger.debug(f"Sending request: {request}")
             self._dragon_head_socket.send_json(req_json, flags)
             response = str(self._dragon_head_socket.recv_json())
-            return t.cast(t.Mapping[str, t.Any], json.loads(response))
+            return response_serializer.deserialize_from_json(response)
 
     def __str__(self) -> str:
         return "Dragon"
@@ -360,3 +371,9 @@ class DragonLauncher(WLMLauncher):
             )
 
             return dragon_envs
+
+
+def _assert_schema_type(typ: t.Type[_SchemaT], obj: object, /) -> _SchemaT:
+    if not isinstance(obj, typ):
+        raise TypeError("Expected schema of type `{typ}`, but got {type(obj)}")
+    return obj

--- a/smartsim/_core/launcher/dragon/dragonLauncher.py
+++ b/smartsim/_core/launcher/dragon/dragonLauncher.py
@@ -41,6 +41,7 @@ import zmq
 import smartsim._core.utils.helpers as _helpers
 from smartsim._core.schemas.dragonRequests import request_serializer
 from smartsim._core.schemas.dragonResponses import response_serializer
+from smartsim._core.schemas.types import NonEmptyStr
 
 from ....error import LauncherError
 from ....log import get_logger
@@ -321,7 +322,7 @@ class DragonLauncher(WLMLauncher):
                     msg += response.error_message
                 raise LauncherError(msg)
 
-            stat_tuple = response.statuses[step_id]
+            stat_tuple = response.statuses[NonEmptyStr(step_id)]
             ret_codes = stat_tuple[1]
             if ret_codes:
                 grp_ret_code = min(ret_codes)

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -143,7 +143,7 @@ def proxyable_launch_cmd(
             status_dir = self.meta["status_dir"]
             run_req = DragonRunRequest.parse_obj(json.loads(original_cmd_list[-1]))
 
-            exe_args = run_req.exe_args or []
+            exe_args = run_req.exe_args
             encoded_cmd = encode_cmd([run_req.exe] + exe_args)
 
             # NOTE: this is NOT safe. should either 1) sign cmd and verify OR 2)

--- a/smartsim/_core/launcher/step/step.py
+++ b/smartsim/_core/launcher/step/step.py
@@ -150,9 +150,9 @@ def proxyable_launch_cmd(
             # NOTE: this is NOT safe. should either 1) sign cmd and verify OR 2)
             #       serialize step and let the indirect entrypoint rebuild the
             #       cmd... for now, test away...
-            # NOTE: This mapping DOES NOT VALIDATE THE STRINGS and we are lying!
-            #       to the type checker. We should try to remove this dragon specific
-            #       branch for more type safety.
+            # NOTE: This mapping DOES NOT VALIDATE THE STRINGS and we are lying
+            #       to pydantic and the type checker! We should try to remove this
+            #       dragon specific branch for more type safety.
             new_cmd = list(
                 map(
                     NonEmptyStr,
@@ -173,8 +173,8 @@ def proxyable_launch_cmd(
                     ),
                 )
             )
-            run_req.exe = NonEmptyStr(new_cmd[0])
-            run_req.exe_args = [NonEmptyStr(s) for s in new_cmd[1:]]
+            run_req.exe = new_cmd[0]
+            run_req.exe_args = new_cmd[1:]
 
             return [run_req.json()]
 

--- a/smartsim/_core/schemas/dragonRequests.py
+++ b/smartsim/_core/schemas/dragonRequests.py
@@ -31,6 +31,9 @@ from pydantic import BaseModel, PositiveInt
 import smartsim._core.schemas.utils as _utils
 from smartsim._core.schemas.types import NonEmptyStr
 
+# Black and Pylint disagree about where to put the `...`
+# pylint: disable=multiple-statements
+
 
 class DragonRequest(BaseModel): ...
 

--- a/smartsim/_core/schemas/dragonResponses.py
+++ b/smartsim/_core/schemas/dragonResponses.py
@@ -31,6 +31,9 @@ from pydantic import BaseModel
 import smartsim._core.schemas.utils as _utils
 from smartsim._core.schemas.types import NonEmptyStr
 
+# Black and Pylint disagree about where to put the `...`
+# pylint: disable=multiple-statements
+
 
 class DragonResponse(BaseModel):
     error_message: t.Optional[str] = None

--- a/smartsim/_core/schemas/dragonResponses.py
+++ b/smartsim/_core/schemas/dragonResponses.py
@@ -24,38 +24,39 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# mypy: disable-error-code="valid-type"
-
 import typing as t
 
-from pydantic import BaseModel, constr
+from pydantic import BaseModel
+
+import smartsim._core.schemas.utils as _utils
+from smartsim._core.schemas.types import NonEmptyStr
 
 
 class DragonResponse(BaseModel):
-    response_type: constr(min_length=1)
     error_message: t.Optional[str] = None
 
 
+response_serializer = _utils.SchemaSerializer[str, DragonResponse]("response_type")
+
+
+@response_serializer.register("run")
 class DragonRunResponse(DragonResponse):
-    response_type: constr(min_length=1) = "run"
-    step_id: constr(min_length=1)
+    step_id: NonEmptyStr
 
 
+@response_serializer.register("status_update")
 class DragonUpdateStatusResponse(DragonResponse):
-    response_type: constr(min_length=1) = "status_update"
     # status is a dict: {step_id: (is_alive, returncode)}
-    statuses: t.Mapping[
-        constr(min_length=1), t.Tuple[constr(min_length=1), t.Optional[t.List[int]]]
-    ] = {}
+    statuses: t.Mapping[NonEmptyStr, t.Tuple[NonEmptyStr, t.Optional[t.List[int]]]] = {}
 
 
-class DragonStopResponse(DragonResponse):
-    response_type: constr(min_length=1) = "stop"
+@response_serializer.register("stop")
+class DragonStopResponse(DragonResponse): ...
 
 
-class DragonHandshakeResponse(DragonResponse):
-    response_type: constr(min_length=1) = "handshake"
+@response_serializer.register("handshake")
+class DragonHandshakeResponse(DragonResponse): ...
 
 
-class DragonBootstrapResponse(DragonResponse):
-    response_type: constr(min_length=1) = "bootstrap"
+@response_serializer.register("bootstrap")
+class DragonBootstrapResponse(DragonResponse): ...

--- a/smartsim/_core/schemas/types.py
+++ b/smartsim/_core/schemas/types.py
@@ -24,55 +24,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import typing as t
-
-from pydantic import BaseModel, PositiveInt
-
-import smartsim._core.schemas.utils as _utils
-from smartsim._core.schemas.types import NonEmptyStr
+import pydantic
 
 
-class DragonRequest(BaseModel): ...
-
-
-request_serializer = _utils.SchemaSerializer[str, DragonRequest]("request_type")
-
-
-class DragonRunRequestView(DragonRequest):
-    exe: NonEmptyStr
-    exe_args: t.List[NonEmptyStr] = []
-    path: NonEmptyStr
-    nodes: PositiveInt = 1
-    tasks: PositiveInt = 1
-    output_file: t.Optional[NonEmptyStr] = None
-    error_file: t.Optional[NonEmptyStr] = None
-    env: t.Dict[str, t.Optional[str]] = {}
-    name: t.Optional[NonEmptyStr]
-    pmi_enabled: bool = True
-
-
-@request_serializer.register("run")
-class DragonRunRequest(DragonRunRequestView):
-    current_env: t.Dict[str, t.Optional[str]] = {}
-
-    def __str__(self) -> str:
-        return str(DragonRunRequestView.parse_obj(self.dict(exclude={"current_env"})))
-
-
-@request_serializer.register("update_status")
-class DragonUpdateStatusRequest(DragonRequest):
-    step_ids: t.List[NonEmptyStr]
-
-
-@request_serializer.register("stop")
-class DragonStopRequest(DragonRequest):
-    step_id: NonEmptyStr
-
-
-@request_serializer.register("handshake")
-class DragonHandshakeRequest(DragonRequest): ...
-
-
-@request_serializer.register("bootstrap")
-class DragonBootstrapRequest(DragonRequest):
-    address: NonEmptyStr
+class NonEmptyStr(pydantic.ConstrainedStr):
+    min_length = 1

--- a/smartsim/_core/schemas/utils.py
+++ b/smartsim/_core/schemas/utils.py
@@ -44,7 +44,7 @@ class SchemaSerializer(t.Generic[_KeyT, _SchemaT]):
         try:
             type_ = obj[self._type_name_key]
         except KeyError:
-            raise ValueError(f"Could not parse type of object: {obj}") from None
+            raise ValueError(f"Could not parse object: {obj}") from None
         try:
             cls = self._map[type_]
         except KeyError:

--- a/smartsim/_core/schemas/utils.py
+++ b/smartsim/_core/schemas/utils.py
@@ -1,0 +1,55 @@
+import json
+import typing as t
+
+import pydantic
+
+_KeyT = t.TypeVar("_KeyT")
+_SchemaT = t.TypeVar("_SchemaT", bound=pydantic.BaseModel)
+
+
+class SchemaSerializer(t.Generic[_KeyT, _SchemaT]):
+    def __init__(
+        self,
+        type_name: str,
+        init_map: t.Optional[t.Mapping[_KeyT, t.Type[_SchemaT]]] = None,
+    ):
+        self._map = dict(init_map) if init_map else {}
+        self._type_name_key = f"__{type_name}__"
+
+    def register(self, key: _KeyT) -> t.Callable[[t.Type[_SchemaT]], t.Type[_SchemaT]]:
+        if key in self._map:
+            raise KeyError(f"Key `{key}` has already been registered for this parser")
+
+        def _register(cls: t.Type[_SchemaT]) -> t.Type[_SchemaT]:
+            self._map[key] = cls
+            return cls
+
+        return _register
+
+    def schema_to_dict(self, schema: _SchemaT) -> t.Dict[str, t.Any]:
+        reverse_map = dict((v, k) for k, v in self._map.items())
+        try:
+            val = reverse_map[type(schema)]
+        except KeyError:
+            raise TypeError(f"Unregistered schema type: {type(schema)}") from None
+        # TODO: This method is deprectated in pydantic >= 2
+        dict_ = schema.dict()
+        dict_[self._type_name_key] = val
+        return dict_
+
+    def serialize_to_json(self, schema: _SchemaT) -> str:
+        return json.dumps(self.schema_to_dict(schema))
+
+    def mapping_to_schema(self, obj: t.Mapping[t.Any, t.Any]) -> _SchemaT:
+        try:
+            type_ = obj[self._type_name_key]
+        except KeyError:
+            raise ValueError(f"Could not parse type of object: {obj}") from None
+        try:
+            cls = self._map[type_]
+        except KeyError:
+            raise ValueError(f"No type of value `{type_}` is registered") from None
+        return cls.parse_obj(obj)
+
+    def deserialize_from_json(self, obj: str) -> _SchemaT:
+        return self.mapping_to_schema(json.loads(obj))

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -310,7 +310,7 @@ def decode_cmd(encoded_cmd: str) -> t.List[str]:
 
 @t.final
 @dataclass(frozen=True)
-class Pipeline(t.Generic[_T]):
+class _Pipeline(t.Generic[_T]):
     """Utility class to turn
 
     ..highlight:: python
@@ -323,22 +323,26 @@ class Pipeline(t.Generic[_T]):
     ..highlight:: python
     ..code-block:: python
 
-        result = (Pipeline(data)
-                  .pipe(some)
-                  .pipe(very)
-                  .pipe(deeply)
-                  .pipe(nested)
-                  .pipe(function)
-                  .pipe(calls)
-                  .result())
+        result = (_Pipeline(data)
+                  .then(some)
+                  .then(very)
+                  .then(deeply)
+                  .then(nested)
+                  .then(function)
+                  .then(calls)
+                  .get_result())
 
     without the need to introduce confusing temporary variable names
     """
 
     _val: _T
 
-    def pipe(self, fn: t.Callable[[_T], _U], /) -> "Pipeline[_U]":
-        return Pipeline(fn(self._val))
+    def then(self, fn: t.Callable[[_T], _U], /) -> "_Pipeline[_U]":
+        return _Pipeline(fn(self._val))
 
-    def result(self) -> _T:
+    def get_result(self) -> _T:
         return self._val
+
+
+def start_with(obj: _T) -> _Pipeline[_T]:
+    return _Pipeline(obj)

--- a/smartsim/_core/utils/helpers.py
+++ b/smartsim/_core/utils/helpers.py
@@ -281,7 +281,7 @@ def get_ts() -> int:
     return int(datetime.timestamp(datetime.now()))
 
 
-def encode_cmd(cmd: t.List[str]) -> str:
+def encode_cmd(cmd: t.Sequence[str]) -> str:
     """Transform a standard command list into an encoded string safe for providing as an
     argument to a proxy entrypoint
     """

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -13,6 +13,6 @@ def test_pipline(func_1, func_2, func_3):
     x = 30
     assert (
         func_3(func_2(func_1(x)))
-        == (helpers._Pipeline(x).then(func_1).then(func_2).then(func_3).get_result())
-        == (helpers.start_with(x).then(func_1).then(func_2).then(func_3).get_result())
+        == helpers._Pipeline(x).then(func_1).then(func_2).then(func_3).get_result()
+        == helpers.start_with(x).then(func_1).then(func_2).then(func_3).get_result()
     )

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,0 +1,16 @@
+import itertools
+
+import pytest
+
+from smartsim._core.utils import helpers
+
+
+@pytest.mark.parametrize(
+    "func_1, func_2, func_3",
+    itertools.permutations((lambda x: x + 3, lambda x: x * 2, lambda x: x // 5)),
+)
+def test_pipline(func_1, func_2, func_3):
+    x = 30
+    assert func_3(func_2(func_1(x))) == (
+        helpers.Pipeline(x).pipe(func_1).pipe(func_2).pipe(func_3).result()
+    )

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -11,6 +11,8 @@ from smartsim._core.utils import helpers
 )
 def test_pipline(func_1, func_2, func_3):
     x = 30
-    assert func_3(func_2(func_1(x))) == (
-        helpers.Pipeline(x).pipe(func_1).pipe(func_2).pipe(func_3).result()
+    assert (
+        func_3(func_2(func_1(x)))
+        == (helpers._Pipeline(x).then(func_1).then(func_2).then(func_3).get_result())
+        == (helpers.start_with(x).then(func_1).then(func_2).then(func_3).get_result())
     )

--- a/tests/utils/test_schema_utils.py
+++ b/tests/utils/test_schema_utils.py
@@ -1,0 +1,103 @@
+import json
+
+import pydantic
+import pytest
+
+from smartsim._core.schemas.utils import SchemaSerializer
+
+
+class Person(pydantic.BaseModel):
+    name: str
+    age: int
+
+
+class Book(pydantic.BaseModel):
+    title: str
+    num_pages: int
+
+
+def test_schema_registrartion():
+    serializer = SchemaSerializer("test_type")
+    assert serializer._map == {}
+
+    serializer.register("person")(Person)
+    assert serializer._map == {"person": Person}
+
+    serializer.register("book")(Book)
+    assert serializer._map == {"person": Person, "book": Book}
+
+
+def test_serialize_schema():
+    serializer = SchemaSerializer("test_type")
+    serializer.register("person")(Person)
+    serializer.register("book")(Book)
+    assert json.loads(serializer.serialize_to_json(Person(name="Bob", age=36))) == {
+        "__test_type__": "person",
+        "name": "Bob",
+        "age": 36,
+    }
+    assert json.loads(
+        serializer.serialize_to_json(
+            Book(title="The Greatest Story of All Time", num_pages=10_000)
+        )
+    ) == {
+        "__test_type__": "book",
+        "title": "The Greatest Story of All Time",
+        "num_pages": 10_000,
+    }
+
+
+def test_serializer_errors_if_types_overloaded():
+    serializer = SchemaSerializer("test_type")
+    serializer.register("schema")(Person)
+
+    with pytest.raises(KeyError):
+        serializer.register("schema")(Book)
+
+
+def test_serializer_errors_on_unknown_schema():
+    serializer = SchemaSerializer("test_type")
+    serializer.register("person")(Person)
+
+    with pytest.raises(TypeError):
+        serializer.serialize_to_json(
+            Book(title="The Shortest Story of All Time", num_pages=1)
+        )
+
+
+def test_deserialize_json():
+    serializer = SchemaSerializer("test_type")
+    serializer.register("person")(Person)
+    serializer.register("book")(Book)
+    assert serializer.deserialize_from_json(
+        json.dumps({"__test_type__": "person", "name": "Bob", "age": 36})
+    ) == Person(name="Bob", age=36)
+    assert serializer.deserialize_from_json(
+        json.dumps(
+            {
+                "__test_type__": "book",
+                "title": "The Most Average Story of All Time",
+                "num_pages": 500,
+            }
+        )
+    ) == Book(title="The Most Average Story of All Time", num_pages=500)
+
+
+def test_deserialize_error_if_type_key_not_recognized():
+    serializer = SchemaSerializer("test_type")
+    serializer.register("person")(Person)
+
+    with pytest.raises(ValueError):
+        serializer.deserialize_from_json(
+            json.dumps(
+                {"__test_type__": "alien", "name": "Bob the Alien", "age": 5_000}
+            )
+        )
+
+
+def test_deserialize_error_if_type_key_is_missing():
+    serializer = SchemaSerializer("test_type")
+    serializer.register("person")(Person)
+
+    with pytest.raises(ValueError):
+        serializer.deserialize_from_json(json.dumps({"name": "Bob", "age": 36}))


### PR DESCRIPTION
This PR will:
- Address small type errors in dragon prototype.
- Promote type safety my moving type information out of instance variables.
- Move serialization/de-serialization of request/response schema out of backend code and into dedicated class to prevent unexpected type coercions using `pydantic.BaseModel.parse_obj`.
- Remove branches based on schema "instance var typenames" from backend and replaces with `functools.singledispatchmethod`