### PR TITLE
Dynamically assign port to dragon bootstrap queue

### DIFF
--- a/smartsim/_core/_cli/validate.py
+++ b/smartsim/_core/_cli/validate.py
@@ -30,7 +30,6 @@ import io
 import multiprocessing as mp
 import os
 import os.path
-import socket
 import tempfile
 import typing as t
 from types import TracebackType
@@ -41,6 +40,7 @@ from smartredis import Client
 from smartsim import Experiment
 from smartsim._core._cli.utils import SMART_LOGGER_FORMAT
 from smartsim._core.utils.helpers import installed_redisai_backends
+from smartsim._core.utils.network import find_free_port
 from smartsim.log import get_logger
 
 logger = get_logger("Smart", fmt=SMART_LOGGER_FORMAT)
@@ -152,7 +152,7 @@ def test_install(
 ) -> None:
     exp = Experiment("ValidationExperiment", exp_path=location, launcher="local")
     exp.disable_telemetry()
-    port = _find_free_port() if port is None else port
+    port = find_free_port() if port is None else port
     with _make_managed_local_orc(exp, port) as client:
         logger.info("Verifying Tensor Transfer")
         client.put_tensor("plain-tensor", np.ones((1, 1, 3, 3)))
@@ -203,14 +203,6 @@ def _make_managed_local_orc(
         yield Client(False, address=client_addr)
     finally:
         exp.stop(orc)
-
-
-def _find_free_port() -> int:
-    """A 'good enough' way to find an open port to bind to"""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("0.0.0.0", 0))
-        _, port = sock.getsockname()
-        return int(port)
 
 
 def _test_tf_install(client: Client, tmp_dir: str, device: _TCapitalDeviceStr) -> None:

--- a/smartsim/_core/launcher/dragon/dragonLauncher.py
+++ b/smartsim/_core/launcher/dragon/dragonLauncher.py
@@ -129,7 +129,7 @@ class DragonLauncher(WLMLauncher):
         if not self.is_connected:
             raise LauncherError("Could not connect to Dragon server")
 
-    # pylint: disable-next=too-many-statements
+    # pylint: disable-next=too-many-statements,too-many-locals
     def _connect_to_dragon(self, path: t.Union[str, "os.PathLike[str]"]) -> None:
         with DRG_LOCK:
             # TODO use manager instead

--- a/smartsim/_core/launcher/dragon/dragonLauncher.py
+++ b/smartsim/_core/launcher/dragon/dragonLauncher.py
@@ -63,7 +63,7 @@ from ...schemas import (
     DragonUpdateStatusRequest,
     DragonUpdateStatusResponse,
 )
-from ...utils.network import get_best_interface_and_address
+from ...utils.network import find_free_port, get_best_interface_and_address
 from ..launcher import WLMLauncher
 from ..step import DragonStep, LocalStep, Step
 from ..stepInfo import StepInfo
@@ -174,9 +174,12 @@ class DragonLauncher(WLMLauncher):
             if address is not None:
                 self._set_timeout(self._startup_timeout)
                 launcher_socket = self._context.socket(zmq.REP)
-                # TODO find first available port >= 5995
-                socket_addr = f"tcp://{address}:5995"
+
+                # find first available port >= 5995
+                port = find_free_port(start=5995)
+                socket_addr = f"tcp://{address}:{port}"
                 logger.debug(f"Binding launcher to {socket_addr}")
+
                 launcher_socket.bind(socket_addr)
                 cmd += ["+launching_address", socket_addr]
 

--- a/smartsim/_core/utils/network.py
+++ b/smartsim/_core/utils/network.py
@@ -97,3 +97,24 @@ def get_best_interface_and_address() -> t.Tuple[t.Optional[str], t.Optional[str]
         if any(interface.startswith(if_prefix) for if_prefix in known_ifs):
             return interface, get_ip_from_interface(interface)
     return None, None
+
+
+def find_free_port(start: int = 0) -> int:
+    """A 'good enough' way to find an open port to bind to
+
+    :param start: The first port number to consider
+    :type start: int
+    :returns: The first open port found
+    :rtype: int
+    """
+    port_num = -1
+    while port_num < 0:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.bind(("0.0.0.0", start))
+                _, port = sock.getsockname()
+                port_num = int(port)
+            except Exception:
+                # swallow connection exception; test if the next port is open
+                start += 1
+    return port_num

--- a/tests/test_dragon_launcher.py
+++ b/tests/test_dragon_launcher.py
@@ -31,7 +31,6 @@ class MockSocket:
 
     def recv_json(self) -> str:
         dbr = DragonBootstrapRequest(address=self._bind_address)
-        # dbr.__request_type__ = "bootstrap"
         return dbr.json()
 
     def close(self) -> None: ...

--- a/tests/test_dragon_launcher.py
+++ b/tests/test_dragon_launcher.py
@@ -1,0 +1,76 @@
+import typing as t
+
+import pytest
+
+from smartsim._core.launcher.dragon.dragonLauncher import DragonLauncher
+from smartsim._core.schemas.dragonRequests import DragonBootstrapRequest
+from smartsim.error.errors import LauncherError
+
+
+class MockPopen:
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None: ...
+
+    @property
+    def pid(self) -> int:
+        return 1
+
+    @property
+    def returncode(self) -> int:
+        return 0
+
+
+class MockSocket:
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        self._bind_address = ""
+
+    def __call__(self, *args: t.Any, **kwds: t.Any) -> t.Any:
+        return self
+
+    def bind(self, addr: str) -> None:
+        self._bind_address = addr
+
+    def recv_json(self) -> str:
+        dbr = DragonBootstrapRequest(address=self._bind_address)
+        # dbr.__request_type__ = "bootstrap"
+        return dbr.json()
+
+    def close(self) -> None: ...
+
+    def send_json(self, json: str) -> None: ...
+
+    @property
+    def bind_address(self) -> str:
+        return self._bind_address
+
+
+def test_dragon_connect_bind_address(monkeypatch: pytest.MonkeyPatch, test_dir: str):
+    """Test the connection to a dragon environment dynamically selects an open port
+    in the range supplied"""
+
+    with monkeypatch.context() as ctx:
+        ctx.setenv("SMARTSIM_DRAGON_SERVER_PATH", test_dir)
+        ctx.setattr(
+            "smartsim._core.launcher.dragon.dragonLauncher.get_best_interface_and_address",
+            lambda: ("faux_interface", "127.0.0.1"),
+        )
+        ctx.setattr(
+            "smartsim._core.launcher.dragon.dragonLauncher.DragonLauncher._handshake",
+            lambda self, address: ...,
+        )
+        ctx.setattr(
+            "smartsim._core.schemas.utils.SchemaSerializer.mapping_to_schema",
+            lambda self, obj: DragonBootstrapRequest.parse_obj(obj),
+        )
+
+        mock_socket = MockSocket()
+
+        ctx.setattr("zmq.Context.socket", mock_socket)
+        ctx.setattr("subprocess.Popen", lambda *args, **kwargs: MockPopen())
+
+        dragon_launcher = DragonLauncher()
+        with pytest.raises(LauncherError) as ex:
+            # it will complain about failure to connect when validating...
+            dragon_launcher.connect_to_dragon(test_dir)
+
+        chosen_port = int(mock_socket.bind_address.split(":")[-1])
+        assert chosen_port >= 5995

--- a/tests/test_dragon_launcher.py
+++ b/tests/test_dragon_launcher.py
@@ -6,6 +6,9 @@ from smartsim._core.launcher.dragon.dragonLauncher import DragonLauncher
 from smartsim._core.schemas.dragonRequests import DragonBootstrapRequest
 from smartsim.error.errors import LauncherError
 
+# The tests in this file belong to the group_a group
+pytestmark = pytest.mark.group_a
+
 
 class MockPopen:
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None: ...

--- a/tests/test_dragon_launcher.py
+++ b/tests/test_dragon_launcher.py
@@ -32,13 +32,19 @@ class MockSocket:
     def bind(self, addr: str) -> None:
         self._bind_address = addr
 
-    def recv_json(self) -> str:
+    # def recv_json(self) -> str:
+    #     dbr = DragonBootstrapRequest(address=self._bind_address)
+    #     return dbr.json()
+
+    def recv_string(self) -> str:
         dbr = DragonBootstrapRequest(address=self._bind_address)
-        return dbr.json()
+        return f"bootstrap|{dbr.json()}"
 
     def close(self) -> None: ...
 
     def send_json(self, json: str) -> None: ...
+
+    def send_string(*args, **kwargs) -> None: ...
 
     @property
     def bind_address(self) -> str:
@@ -58,10 +64,6 @@ def test_dragon_connect_bind_address(monkeypatch: pytest.MonkeyPatch, test_dir: 
         ctx.setattr(
             "smartsim._core.launcher.dragon.dragonLauncher.DragonLauncher._handshake",
             lambda self, address: ...,
-        )
-        ctx.setattr(
-            "smartsim._core.schemas.utils.SchemaSerializer.mapping_to_schema",
-            lambda self, obj: DragonBootstrapRequest.parse_obj(obj),
         )
 
         mock_socket = MockSocket()

--- a/tests/utils/test_network.py
+++ b/tests/utils/test_network.py
@@ -2,6 +2,9 @@ import pytest
 
 from smartsim._core.utils.network import find_free_port
 
+# The tests in this file belong to the group_a group
+pytestmark = pytest.mark.group_a
+
 
 def test_find_free_port_no_start():
     """Test that a free port is identified and returned when no

--- a/tests/utils/test_network.py
+++ b/tests/utils/test_network.py
@@ -1,0 +1,27 @@
+import pytest
+
+from smartsim._core.utils.network import find_free_port
+
+
+def test_find_free_port_no_start():
+    """Test that a free port is identified and returned when no
+    starting port number is specified"""
+    port = find_free_port()
+    assert port > 0
+
+
+@pytest.mark.parametrize(
+    "start_at",
+    [
+        pytest.param(1000, id="start at 1000"),
+        pytest.param(2000, id="start at 2000"),
+        pytest.param(5000, id="start at 5000"),
+        pytest.param(10000, id="start at 10000"),
+        pytest.param(16000, id="start at 16000"),
+    ],
+)
+def test_find_free_port_range_specified(start_at):
+    """Test that a free port greater than or equal to the specified
+    starting port number is identified and returned"""
+    port = find_free_port(start_at)
+    assert port >= start_at


### PR DESCRIPTION
## Feature added

Dynamically assigns a port number to the bootstrap queue.

## Changes

1. move/rename `_find_free_port` from cli subpackage to network where it makes sense and doesn't cause a circular reference
2. tweak `find_free_port` to take a starting port number to enable port-range preference
3. use new `find_free_port` in cli in place of prior `_find_free_port`
